### PR TITLE
Initial commit for synthetic trace generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Eclipse Files
+.settings/*
+.classpath
+.project
+target/*
+/target/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# synthetic-load-generator
-A utility to generate synthetic operational data (traces, metrics, logs, events) load simulating a microservice-based application.
+# Synthetic Load Generator
+
+The synthetic load generator is a utility to generate synthetic operational
+data (traces, metrics, logs, events) for a simulated microservice-based application.
+The application is modeled through its topology and operation models for each
+of the components within the topology.
+
+## Building and running
+
+Building:
+```
+mvn package
+```
+
+Running with sample topology:
+```
+java -jar ./target/SyntheticLoadGenerator-1.0-SNAPSHOT-jar-with-dependencies.jar  --paramsFile ./topologies/hipster-shop.json --jaegerCollectorUrl http://localhost:14268
+```
+
+This assumes that you have the `jaeger-collector` component running and listening
+on port 14268 for thrift/HTTP protocol/transport.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.omnition.loadgenerator</groupId>
+  <artifactId>SyntheticLoadGenerator</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>SyntheticLoadGenerator</name>
+  <url>https://omnition.io/</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <version.io.jaegertracing>0.28.0</version.io.jaegertracing>
+    <version.log4j>1.2.17</version.log4j>
+    <version.slf4j>1.7.5</version.slf4j>
+    <version.apache.commons>3.7</version.apache.commons>
+    <version.jcommander>1.72</version.jcommander>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.jaegertracing</groupId>
+      <artifactId>jaeger-core</artifactId>
+      <version>${version.io.jaegertracing}</version>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>${version.log4j}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${version.slf4j}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${version.slf4j}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${version.apache.commons}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+      <version>${version.jcommander}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <archive>
+            <manifest>
+              <mainClass>io.omnition.loadgenerator.App</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/io/omnition/loadgenerator/App.java
+++ b/src/main/java/io/omnition/loadgenerator/App.java
@@ -1,0 +1,96 @@
+package io.omnition.loadgenerator;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.log4j.Logger;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.google.gson.Gson;
+
+import io.omnition.loadgenerator.LoadGeneratorParams.RootServiceRoute;
+import io.omnition.loadgenerator.util.JaegerTraceEmitter;
+import io.omnition.loadgenerator.util.ScheduledTraceGenerator;
+
+public class App {
+    private final static Logger logger = Logger.getLogger(App.class);
+
+    @Parameter(names = "--paramsFile", description = "Name of the file containing the topology params", required = true)
+    private String topologyFile;
+
+    @Parameter(names = "--jaegerCollectorUrl", description = "URL of the jaeger collector", required = true)
+    private String jaegerCollectorUrl;
+
+    @Parameter(names = "--flushIntervalMillis", description = "How often to flush traces", required = false)
+    private long flushIntervalMillis = TimeUnit.SECONDS.toMillis(5);
+
+    @Parameter(names = { "--help", "-h" }, help = true)
+    private boolean help;
+
+    private List<ScheduledTraceGenerator> scheduledTraceGenerators = new ArrayList<>();
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    public static void main(String[] args) {
+        App app = new App();
+        JCommander.newBuilder().addObject(app).build().parse(args);
+        try {
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                public void run() {
+                    try {
+                        app.shutdown();
+                    } catch (Exception e) {
+                        logger.error("Error shutting down: " + e, e);
+                    }
+                }
+            });
+            app.init();
+            app.start();
+        } catch (Exception e) {
+            logger.error("Error running load generator: " + e, e);
+            System.exit(1);
+        }
+    }
+
+    public void init() throws Exception {
+        File f = new File(this.topologyFile);
+        if(!f.exists() || f.isDirectory()) {
+            logger.error("Invalid topology file specified: " + this.topologyFile);
+            throw new FileNotFoundException(this.topologyFile);
+        }
+
+        String json = new String(Files.readAllBytes(Paths.get(this.topologyFile)), "UTF-8");
+        Gson gson = new Gson();
+        LoadGeneratorParams params = gson.fromJson(json, LoadGeneratorParams.class);
+        logger.info("Params: " + gson.toJson(params));
+        JaegerTraceEmitter emitter = new JaegerTraceEmitter(jaegerCollectorUrl, (int)flushIntervalMillis);
+        for (RootServiceRoute route : params.rootRoutes) {
+            this.scheduledTraceGenerators.add(new ScheduledTraceGenerator(
+                    params.topology, route.service, route.route,
+                    route.tracesPerHour, emitter));
+        }
+    }
+
+    public void start() throws Exception {
+        for (ScheduledTraceGenerator gen : this.scheduledTraceGenerators) {
+            gen.start();
+        }
+        latch.await();
+    }
+
+    public void shutdown() throws Exception {
+        for (ScheduledTraceGenerator gen : this.scheduledTraceGenerators) {
+            gen.shutdown();
+        }
+        for (ScheduledTraceGenerator gen : this.scheduledTraceGenerators) {
+            gen.awaitTermination();
+        }
+        latch.countDown();
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/LoadGeneratorParams.java
+++ b/src/main/java/io/omnition/loadgenerator/LoadGeneratorParams.java
@@ -1,0 +1,17 @@
+package io.omnition.loadgenerator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.omnition.loadgenerator.model.topology.Topology;
+
+public class LoadGeneratorParams {
+    public Topology topology;
+    public List<RootServiceRoute> rootRoutes = new ArrayList<>();
+
+    public class RootServiceRoute {
+        public String service;
+        public String route;
+        public int tracesPerHour;
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/model/topology/OperationModel.java
+++ b/src/main/java/io/omnition/loadgenerator/model/topology/OperationModel.java
@@ -1,0 +1,7 @@
+package io.omnition.loadgenerator.model.topology;
+
+public class OperationModel {
+    public int errorPercent = 0;
+    public int errorCode = 503;
+    public int maxLatencyMillis = 0;
+}

--- a/src/main/java/io/omnition/loadgenerator/model/topology/ServiceRoute.java
+++ b/src/main/java/io/omnition/loadgenerator/model/topology/ServiceRoute.java
@@ -1,0 +1,10 @@
+package io.omnition.loadgenerator.model.topology;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ServiceRoute {
+    public String route;
+    public Map<String, String> downstreamCalls = new HashMap<>();
+    public OperationModel operationModel;
+}

--- a/src/main/java/io/omnition/loadgenerator/model/topology/ServiceTier.java
+++ b/src/main/java/io/omnition/loadgenerator/model/topology/ServiceTier.java
@@ -1,0 +1,24 @@
+package io.omnition.loadgenerator.model.topology;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ServiceTier {
+    public String serviceName;
+    public Map<String, String> tags = new HashMap<>();
+    public List<ServiceRoute> routes = new ArrayList<>();
+    public List<String> instances = new ArrayList<>();
+
+    public ServiceRoute getRoute(String routeName) {
+        return this.routes.stream()
+                .filter(r -> r.route.equalsIgnoreCase(routeName))
+                .findFirst().get();
+    }
+
+    public OperationModel getOperationModel(String instanceName, String routeName) {
+        return this.routes.stream().filter(r -> r.route.equals(routeName))
+                .findFirst().get().operationModel;
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/model/topology/Topology.java
+++ b/src/main/java/io/omnition/loadgenerator/model/topology/Topology.java
@@ -1,0 +1,13 @@
+package io.omnition.loadgenerator.model.topology;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Topology {
+    public List<ServiceTier> services = new ArrayList<>();
+
+    public ServiceTier getServiceTier(String serviceName) {
+        return this.services.stream().filter(s -> s.serviceName.equalsIgnoreCase(serviceName))
+                .findFirst().get();
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/model/trace/KeyValue.java
+++ b/src/main/java/io/omnition/loadgenerator/model/trace/KeyValue.java
@@ -1,0 +1,38 @@
+package io.omnition.loadgenerator.model.trace;
+
+public class KeyValue {
+    public static final String STRING_VALUE_TYPE = "string";
+    public static final String LONG_VALUE_TYPE = "long";
+    public static final String BOOLEAN_VALUE_TYPE = "bool";
+    public String key;
+    public String valueType;
+
+    // TODO there are more types: double, binary, not needed at the moment
+    public String valueString;
+    public Boolean valueBool;
+    public Long valueLong;
+
+    public static KeyValue ofStringType(String key, String value) {
+        KeyValue kv = new KeyValue();
+        kv.key = key;
+        kv.valueType = STRING_VALUE_TYPE;
+        kv.valueString = value;
+        return kv;
+    }
+
+    public static KeyValue ofLongType(String key, Long value) {
+        KeyValue kv = new KeyValue();
+        kv.key = key;
+        kv.valueType = LONG_VALUE_TYPE;
+        kv.valueLong = value;
+        return kv;
+    }
+
+    public static KeyValue ofBooleanType(String key, Boolean value) {
+        KeyValue kv = new KeyValue();
+        kv.key = key;
+        kv.valueType = BOOLEAN_VALUE_TYPE;
+        kv.valueBool = value;
+        return kv;
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/model/trace/Reference.java
+++ b/src/main/java/io/omnition/loadgenerator/model/trace/Reference.java
@@ -1,0 +1,19 @@
+package io.omnition.loadgenerator.model.trace;
+
+import java.util.UUID;
+
+public class Reference {
+    public enum RefType {
+        CHILD_OF, FOLLOWS_FROM
+    }
+
+    public RefType refType;
+    public UUID fromSpanId;
+    public UUID toSpanId;
+
+    public Reference(RefType refType, UUID fromSpanId, UUID toSpanId) {
+        this.refType = refType;
+        this.fromSpanId = fromSpanId;
+        this.toSpanId = toSpanId;
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/model/trace/Service.java
+++ b/src/main/java/io/omnition/loadgenerator/model/trace/Service.java
@@ -1,0 +1,15 @@
+package io.omnition.loadgenerator.model.trace;
+
+import java.util.List;
+
+public class Service {
+    public String serviceName;
+    public String instanceName;
+    public List<KeyValue> tags;
+
+    public Service(String serviceName, String instanceName, List<KeyValue> tags) {
+        this.serviceName = serviceName;
+        this.instanceName = instanceName;
+        this.tags = tags;
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/model/trace/Span.java
+++ b/src/main/java/io/omnition/loadgenerator/model/trace/Span.java
@@ -1,0 +1,45 @@
+package io.omnition.loadgenerator.model.trace;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import io.omnition.loadgenerator.util.SpanConventions;
+
+public class Span {
+    public final UUID id = UUID.randomUUID();
+    public Service service;
+    public Long startTimeMicros;
+    public Long endTimeMicros;
+    public String operationName;
+    public List<KeyValue> tags = new ArrayList<>();
+    public List<Reference> refs = new ArrayList<>();
+
+    public void markError() {
+        this.tags.add(KeyValue.ofBooleanType(SpanConventions.IS_ERROR_KEY, true));
+    }
+
+    public void markRootCauseError() {
+        this.tags.add(KeyValue.ofBooleanType(SpanConventions.IS_ROOT_CAUSE_ERROR_KEY, true));
+    }
+
+    public void setHttpCode(int code) {
+        this.tags.add(KeyValue.ofLongType(SpanConventions.HTTP_STATUS_CODE_KEY, (long)code));
+    }
+
+    public int getHttpCodeOrDefault(int defaultCode) {
+        long code = tags.stream()
+                .filter(kv -> kv.key.equalsIgnoreCase(SpanConventions.HTTP_STATUS_CODE_KEY))
+                .map(kv -> kv.valueLong)
+                .findFirst().orElse((long)defaultCode);
+        return (int)code;
+    }
+
+    public void setHttpUrl(String url) {
+        this.tags.add(KeyValue.ofStringType(SpanConventions.HTTP_URL_KEY, url));
+    }
+
+    public void setHttpMethod(String method) {
+        this.tags.add(KeyValue.ofStringType(SpanConventions.HTTP_METHOD_KEY, method));
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/model/trace/Trace.java
+++ b/src/main/java/io/omnition/loadgenerator/model/trace/Trace.java
@@ -1,0 +1,28 @@
+package io.omnition.loadgenerator.model.trace;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class Trace {
+    public Span rootSpan;
+    public List<Span> spans = new ArrayList<>();
+    public Map<UUID, Span> spanIdToSpan = new HashMap<>();
+    public Map<UUID, List<Reference>> spanIdToOutgoingRefs = new HashMap<>();
+
+    public void addSpan(Span span) {
+        this.spans.add(span);
+        this.spanIdToSpan.put(span.id, span);
+    }
+
+    public void addRefs() {
+        for (Span span : spans) {
+            for (Reference ref : span.refs) {
+                this.spanIdToOutgoingRefs.computeIfAbsent(ref.fromSpanId, id -> new ArrayList<>())
+                .add(ref);
+            }
+        }
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/util/ITraceEmitter.java
+++ b/src/main/java/io/omnition/loadgenerator/util/ITraceEmitter.java
@@ -1,0 +1,8 @@
+package io.omnition.loadgenerator.util;
+
+import io.omnition.loadgenerator.model.trace.Trace;
+
+public interface ITraceEmitter {
+
+    String emit(Trace trace);
+}

--- a/src/main/java/io/omnition/loadgenerator/util/JaegerTraceEmitter.java
+++ b/src/main/java/io/omnition/loadgenerator/util/JaegerTraceEmitter.java
@@ -1,0 +1,149 @@
+package io.omnition.loadgenerator.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableObject;
+import org.apache.log4j.Logger;
+
+import io.jaegertracing.Tracer;
+import io.jaegertracing.Tracer.Builder;
+import io.jaegertracing.exceptions.SenderException;
+import io.jaegertracing.reporters.RemoteReporter;
+import io.jaegertracing.samplers.ConstSampler;
+import io.jaegertracing.senders.HttpSender;
+import io.omnition.loadgenerator.model.trace.KeyValue;
+import io.omnition.loadgenerator.model.trace.Service;
+import io.omnition.loadgenerator.model.trace.Span;
+import io.omnition.loadgenerator.model.trace.Trace;
+import io.opentracing.Tracer.SpanBuilder;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMapInjectAdapter;
+
+public class JaegerTraceEmitter implements ITraceEmitter {
+    private final static Logger logger = Logger.getLogger(JaegerTraceEmitter.class);
+    private final Map<String, TracerWrapper> serviceNameToTracer = new HashMap<>();
+    private final String collectorUrl;
+    private final int flushIntervalMillis;
+
+    public JaegerTraceEmitter(String collectorUrl, int flushIntervalMillis) {
+        this.collectorUrl = collectorUrl;
+        this.flushIntervalMillis = flushIntervalMillis;
+    }
+
+    public void close() {
+        serviceNameToTracer.forEach((name, tracer) -> {
+            try {
+                tracer.sender.flush();
+                tracer.tracer.close();
+            } catch (SenderException e) {
+                logger.warn(String.format("Error when flushing trace for service %s", name), e);
+                throw new IllegalArgumentException(e);
+            }
+        });
+    }
+
+    public String emit(Trace trace) {
+        final MutableObject<String> traceId = new MutableObject<String>(null);
+        final Map<UUID, io.opentracing.Span> spanIdToOtSpan = new HashMap<>();
+        Consumer<Span> createOtSpan = span -> {
+            boolean extract = StringUtils.isEmpty(traceId.getValue());
+            String tid = this.createOtSpanForModelSpan(span, spanIdToOtSpan, extract);
+            if (extract) {
+                traceId.setValue(tid);
+            }
+        };
+        Consumer<Span> closeOtSpan = span -> {
+            // mark span as closed
+            spanIdToOtSpan.get(span.id).finish(span.endTimeMicros);
+        };
+        TraceTraversal.prePostOrder(trace, createOtSpan, closeOtSpan);
+        return traceId.getValue();
+    }
+
+    private String createOtSpanForModelSpan(
+            Span span, Map<UUID, io.opentracing.Span> spanIdToOtSpan, boolean extractTraceId) {
+        Tracer tracer = getTracer(span.service).tracer;
+        SpanBuilder otSpanBld = tracer.buildSpan(span.operationName)
+                .withStartTimestamp(span.startTimeMicros);
+        for (KeyValue tag : span.tags) {
+            this.addModelTag(tag, otSpanBld);
+        }
+        span.refs.forEach(ref -> {
+            switch (ref.refType) {
+            case CHILD_OF:
+                otSpanBld.addReference(io.opentracing.References.CHILD_OF,
+                        spanIdToOtSpan.get(ref.fromSpanId).context());
+                break;
+            case FOLLOWS_FROM:
+                otSpanBld.addReference(io.opentracing.References.FOLLOWS_FROM,
+                        spanIdToOtSpan.get(ref.fromSpanId).context());
+                break;
+            default:
+                break;
+            }
+        });
+        io.opentracing.Span otSpan = otSpanBld.start();
+        spanIdToOtSpan.put(span.id, otSpan);
+
+        if (extractTraceId) {
+            return this.extractTraceId(tracer, otSpan);
+        } else {
+            return null;
+        }
+    }
+
+    private String extractTraceId(Tracer tracer, io.opentracing.Span otSpan) {
+        HashMap<String, String> baggage = new HashMap<>();
+        TextMapInjectAdapter map = new TextMapInjectAdapter(baggage);
+        tracer.inject(otSpan.context(), Format.Builtin.HTTP_HEADERS, map);
+        try {
+            String encodedTraceId = URLDecoder.decode(baggage.get("uber-trace-id"), "UTF-8");
+            return encodedTraceId.split(":")[0];
+        } catch (UnsupportedEncodingException e) {
+            logger.error(e);
+            return null;
+        }
+    }
+
+    private SpanBuilder addModelTag(KeyValue tag, SpanBuilder otSpanBld) {
+        if (tag.valueType.equalsIgnoreCase(KeyValue.STRING_VALUE_TYPE)) {
+            otSpanBld = otSpanBld.withTag(tag.key, tag.valueString);
+        } else if (tag.valueType.equalsIgnoreCase(KeyValue.BOOLEAN_VALUE_TYPE)) {
+            otSpanBld = otSpanBld.withTag(tag.key, tag.valueBool);
+        } else if (tag.valueType.equalsIgnoreCase(KeyValue.LONG_VALUE_TYPE)) {
+            otSpanBld = otSpanBld.withTag(tag.key, tag.valueLong);
+        } // other types are ignored for now
+        return otSpanBld;
+    }
+
+    private TracerWrapper getTracer(Service service) {
+        return this.serviceNameToTracer.computeIfAbsent(service.serviceName,
+                s -> new TracerWrapper(this.collectorUrl, service, this.flushIntervalMillis));
+    }
+
+    private static final class TracerWrapper {
+        public HttpSender sender;
+        public RemoteReporter reporter;
+        public Tracer tracer;
+
+        public TracerWrapper(String collectorUrl, Service svc, int flushIntervalMillis) {
+            sender = new HttpSender.Builder(collectorUrl + "/api/traces").build();
+            reporter = new RemoteReporter.Builder().withSender(sender)
+                    .withMaxQueueSize(100000)
+                    .withFlushInterval(flushIntervalMillis)
+                    .build();
+            Builder bld = new Builder(svc.serviceName).withReporter(reporter)
+                    .withSampler(new ConstSampler(true));
+            for (KeyValue kv : svc.tags) {
+                bld.withTag(kv.key, kv.valueString);
+            }
+            tracer = bld.build();
+        }
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/util/ScheduledTraceGenerator.java
+++ b/src/main/java/io/omnition/loadgenerator/util/ScheduledTraceGenerator.java
@@ -1,0 +1,74 @@
+package io.omnition.loadgenerator.util;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.log4j.Logger;
+
+import io.omnition.loadgenerator.model.topology.Topology;
+import io.omnition.loadgenerator.model.trace.Trace;
+
+public class ScheduledTraceGenerator {
+    private static final Logger logger = Logger.getLogger(ScheduledTraceGenerator.class);
+    private static final long GRACEFUL_SHUTDOWN_TIME_SEC = 5;
+    private static final int NUM_THREADS = 5;
+    private final ScheduledExecutorService scheduler;
+
+    private final int tracesPerHour;
+    private final Topology topology;
+    private final String service;
+    private final String route;
+    private final ITraceEmitter emitter;
+
+    public ScheduledTraceGenerator(
+            Topology topology, String service, String route, int tracesPerHour, ITraceEmitter emitter) {
+        this.scheduler = Executors.newScheduledThreadPool(NUM_THREADS);
+        this.tracesPerHour = tracesPerHour;
+        this.topology = topology;
+        this.service = service;
+        this.route = route;
+        this.emitter = emitter;
+    }
+
+    public void start() {
+        logger.info(String.format("Starting trace generation for service %s, route %s, %d traces/hr",
+                this.service, this.route, this.tracesPerHour));
+        scheduler.scheduleAtFixedRate(() -> emitOneTrace(), TimeUnit.SECONDS.toMillis(1),
+                TimeUnit.HOURS.toMillis(1) / this.tracesPerHour, TimeUnit.MILLISECONDS);
+    }
+
+    public void shutdown() {
+        scheduler.shutdown();
+        try {
+            if (!scheduler.awaitTermination(GRACEFUL_SHUTDOWN_TIME_SEC, TimeUnit.SECONDS)) {
+                logger.error("Executor did not terminate in the specified time.");
+                List<Runnable> droppedTasks = scheduler.shutdownNow(); // optional **
+                logger.error("Executor was abruptly shut down. " + droppedTasks.size()
+                        + " tasks will not be executed.");
+            } else {
+                logger.info("Graceful shutdown completed");
+            }
+        } catch (InterruptedException e) {
+            logger.error("Interrupted while waiting for termination", e);
+        }
+    }
+
+    public void awaitTermination() throws InterruptedException {
+        scheduler.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
+    }
+
+    private void emitOneTrace() {
+        try {
+            long now = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis());
+            Trace trace = TraceGenerator.generate(this.topology, this.service, this.route, now);
+            String traceId = this.emitter.emit(trace);
+            logger.info(String.format("Emitted traceId %s for service %s route %s",
+                    traceId, this.service, this.route));
+        } catch (Exception e) {
+            logger.error(String.format("Error emit trace for service %s route %s, reason: %s",
+                    this.service, this.route, e), e);
+        }
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/util/SpanConventions.java
+++ b/src/main/java/io/omnition/loadgenerator/util/SpanConventions.java
@@ -1,0 +1,13 @@
+package io.omnition.loadgenerator.util;
+
+public class SpanConventions {
+    // Span tags as suggested by OpenTracing semantic conventions here:
+    // https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+    public static String HTTP_METHOD_KEY = "http.method";
+    public static String HTTP_STATUS_CODE_KEY = "http.status_code";
+    public static String HTTP_URL_KEY = "http.url";
+    public static String IS_ERROR_KEY = "error";
+
+    // Omnition conventions
+    public static String IS_ROOT_CAUSE_ERROR_KEY = "root_cause_error";
+}

--- a/src/main/java/io/omnition/loadgenerator/util/TraceGenerator.java
+++ b/src/main/java/io/omnition/loadgenerator/util/TraceGenerator.java
@@ -1,0 +1,82 @@
+package io.omnition.loadgenerator.util;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import io.omnition.loadgenerator.model.topology.OperationModel;
+import io.omnition.loadgenerator.model.topology.ServiceRoute;
+import io.omnition.loadgenerator.model.topology.ServiceTier;
+import io.omnition.loadgenerator.model.topology.Topology;
+import io.omnition.loadgenerator.model.trace.KeyValue;
+import io.omnition.loadgenerator.model.trace.Reference;
+import io.omnition.loadgenerator.model.trace.Reference.RefType;
+import io.omnition.loadgenerator.model.trace.Service;
+import io.omnition.loadgenerator.model.trace.Span;
+import io.omnition.loadgenerator.model.trace.Trace;
+
+public class TraceGenerator {
+    private final Random random = new Random();
+    private final Trace trace = new Trace();
+    private Topology topology;
+
+    public static Trace generate(Topology topology, String rootServiceName, String rootRouteName, long startTimeMicros) {
+        TraceGenerator gen = new TraceGenerator(topology);
+        ServiceTier rootServiceTier = gen.topology.getServiceTier(rootServiceName);
+        Span rootSpan = gen.createSpanForServiceRouteCall(rootServiceTier, rootRouteName, startTimeMicros);
+        gen.trace.rootSpan = rootSpan;
+        gen.trace.addRefs();
+        return gen.trace;
+    }
+
+    private TraceGenerator(Topology topology) {
+        this.topology = topology;
+    }
+
+    private Span createSpanForServiceRouteCall(ServiceTier serviceTier, String routeName, long startTimeMicros) {
+        String instanceName = serviceTier.instances.get(
+                random.nextInt(serviceTier.instances.size()));
+        ServiceRoute route = serviceTier.getRoute(routeName);
+        OperationModel om = serviceTier.getOperationModel(instanceName, routeName);
+
+        // send tags of service and service instance
+        List<KeyValue> tags = serviceTier.tags.entrySet().stream()
+                .map(t -> KeyValue.ofStringType(t.getKey(), t.getValue())).collect(Collectors.toList());
+        Service service = new Service(serviceTier.serviceName, instanceName, tags);
+        Span span = new Span();
+        span.startTimeMicros = startTimeMicros;
+        span.operationName = route.route;
+        span.service = service;
+        span.setHttpMethod("GET");
+        span.setHttpUrl(String.format("http://" + serviceTier.serviceName + routeName));
+
+        final AtomicLong maxEndTime = new AtomicLong(startTimeMicros);
+        if (random.nextInt(100) < om.errorPercent) {
+            // inject error and terminate trace there
+            span.markError();
+            span.markRootCauseError();
+            span.setHttpCode(om.errorCode);
+        } else {
+            // no error, make downstream calls
+            route.downstreamCalls.forEach((s, r) -> {
+                long childStartTimeMicros = startTimeMicros + (1 + random.nextInt(om.maxLatencyMillis));
+                ServiceTier childSvc = this.topology.getServiceTier(s);
+                Span childSpan = createSpanForServiceRouteCall(childSvc, r, childStartTimeMicros);
+                Reference ref = new Reference(RefType.CHILD_OF, span.id, childSpan.id);
+                childSpan.refs.add(ref);
+                maxEndTime.set(Math.max(maxEndTime.get(), childSpan.endTimeMicros));
+                int childCode = childSpan.getHttpCodeOrDefault(200);
+                if (childCode != 200) {
+                    span.setHttpCode(childCode);
+                    span.markError();
+                }
+            });
+        }
+        long ownDuration = TimeUnit.MILLISECONDS.toMicros((long)this.random.nextInt(om.maxLatencyMillis));
+        span.endTimeMicros = maxEndTime.get() + ownDuration;
+        trace.addSpan(span);
+        return span;
+    }
+}

--- a/src/main/java/io/omnition/loadgenerator/util/TraceTraversal.java
+++ b/src/main/java/io/omnition/loadgenerator/util/TraceTraversal.java
@@ -1,0 +1,26 @@
+package io.omnition.loadgenerator.util;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.omnition.loadgenerator.model.trace.Reference;
+import io.omnition.loadgenerator.model.trace.Span;
+import io.omnition.loadgenerator.model.trace.Trace;
+
+public class TraceTraversal {
+    public static void prePostOrder(Trace trace, Consumer<Span> preVisitConsumer, Consumer<Span> postVisitConsumer) {
+        prePostOrder(trace, trace.rootSpan, preVisitConsumer, postVisitConsumer);
+    }
+
+    private static void prePostOrder(Trace trace, Span span, Consumer<Span> preVisitConsumer,
+            Consumer<Span> postVisitConsumer) {
+        preVisitConsumer.accept(span);
+        List<Reference> outgoing = trace.spanIdToOutgoingRefs.get(span.id);
+        if (outgoing != null) {
+            outgoing.stream()
+            .map(ref -> trace.spanIdToSpan.get(ref.toSpanId))
+            .forEach(descendant -> prePostOrder(trace, descendant, preVisitConsumer, postVisitConsumer));
+        }
+        postVisitConsumer.accept(span);
+    }
+}

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Set everything to be logged to the console
+log4j.rootCategory=WARN, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+log4j.logger.io.omnition=INFO
+

--- a/src/test/java/io/omnition/loadgenerator/AppTest.java
+++ b/src/test/java/io/omnition/loadgenerator/AppTest.java
@@ -1,0 +1,20 @@
+package io.omnition.loadgenerator;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+{
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue()
+    {
+        assertTrue( true );
+    }
+}

--- a/topologies/hipster-shop.json
+++ b/topologies/hipster-shop.json
@@ -1,0 +1,59 @@
+{
+  "topology" : {
+    "services" : [
+      {
+        "serviceName" : "frontend",
+        "instances" : [ "frontend-6b654dbf57-zq8dt", "frontend-d847fdcf5-j6s2f" ],
+        "tags" : { "version" : "v125", "region" : "us-east-1" },
+        "routes" : [
+          {
+            "route" : "/product",
+            "downstreamCalls" : { "productcatalogservice" :  "/ListProducts" },
+            "operationModel" : { "errorPercent" : 0, "errorCode" : 503, "maxLatencyMillis" : 1000 }
+          },
+          {
+            "route" : "/cart",
+            "downstreamCalls" : { "cartservice" :  "/GetCart" },
+            "operationModel" : { "errorPercent" : 0, "errorCode" : 503, "maxLatencyMillis" : 1000 }
+          }
+        ]
+      },
+      {
+        "serviceName" : "productcatalogservice",
+        "instances" : [ "productcatalogservice-6b654dbf57-zq8dt", "productcatalogservice-d847fdcf5-j6s2f" ],
+        "tags" : { "version" : "v52", "region" : "us-east-1" },
+        "routes" : [
+          {
+            "route" : "/ListProducts",
+            "downstreamCalls" : { },
+            "operationModel" : { "errorPercent" : 20, "errorCode" : 503, "maxLatencyMillis" : 2000 }
+          }
+        ]
+      },
+      {
+        "serviceName" : "cartservice",
+        "instances" : [ "cartservice-6b654dbf57-zq8dt", "cartservice-d847fdcf5-j6s2f" ],
+        "tags" : { "version" : "v5", "region" : "us-east-1" },
+        "routes" : [
+          {
+            "route" : "/GetCart",
+            "downstreamCalls" : { },
+            "operationModel" : { "errorPercent" : 10, "errorCode" : 503, "maxLatencyMillis" : 2000 }
+          }
+        ]
+      }
+    ]
+  },
+  "rootRoutes" : [
+    {
+      "service" : "frontend",
+      "route" : "/product",
+      "tracesPerHour" : 3600
+    },
+    {
+      "service" : "frontend",
+      "route" : "/cart",
+      "tracesPerHour" : 3600
+    }
+  ]
+}


### PR DESCRIPTION
This change adds in a java project for the synthetic load generator.
The code generates traces for the specified application topology and
operation model parameters and root service/routes.

Included is a sample application topology modeling a subset of the
OpenCensus sample hipster shop application.