### PR TITLE
Add service level tags demo

### DIFF
--- a/src/main/java/io/omnition/loadgenerator/model/topology/ServiceRoute.java
+++ b/src/main/java/io/omnition/loadgenerator/model/topology/ServiceRoute.java
@@ -9,5 +9,4 @@ public class ServiceRoute {
     public String route;
     public Map<String, String> downstreamCalls = new HashMap<>();
     public List<TagSet> tagSets = new ArrayList<>();
-    public int maxLatencyMillis;
 }

--- a/src/main/java/io/omnition/loadgenerator/model/topology/ServiceTier.java
+++ b/src/main/java/io/omnition/loadgenerator/model/topology/ServiceTier.java
@@ -47,10 +47,18 @@ public class ServiceTier {
                         mergedSet.tags = new HashMap<>(serviceSet.tags);
                         mergedSet.inherit = new ArrayList<>(serviceSet.inherit);
                         mergedSet.tagGenerators = new ArrayList<>(serviceSet.tagGenerators);
+                        mergedSet.maxLatency = serviceSet.maxLatency;
+                        mergedSet.minLatency = serviceSet.minLatency;
 
                         mergedSet.tags.putAll(routeSet.tags);
                         mergedSet.inherit.addAll(routeSet.inherit);
                         mergedSet.tagGenerators.addAll(routeSet.tagGenerators);
+                        if (routeSet.maxLatency != null) {
+                            mergedSet.maxLatency = routeSet.maxLatency;
+                        }
+                        if (routeSet.minLatency != null) {
+                            mergedSet.minLatency = routeSet.minLatency;
+                        }
                         mergedSet.setWeight(routeSet.getWeight() * serviceSet.getWeight());
                         total += mergedSet.getWeight();
                         treeMap.put(total, mergedSet);

--- a/src/main/java/io/omnition/loadgenerator/model/topology/TagSet.java
+++ b/src/main/java/io/omnition/loadgenerator/model/topology/TagSet.java
@@ -4,12 +4,18 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 public class TagSet {
+    private static Random random = new Random();
+
     private Integer weight;
+
     public Map<String, Object> tags = new HashMap<>();
     public List<TagGenerator> tagGenerators = new ArrayList<>();
     public List<String> inherit = new ArrayList<>();
+    public Integer maxLatency;
+    public Integer minLatency;
 
     public void setWeight(int weight) {
         if (weight <= 0) {
@@ -23,5 +29,16 @@ public class TagSet {
             return 1;
         }
         return weight;
+    }
+
+    public int randomLatency() {
+        if (maxLatency == null) {
+            throw new IllegalArgumentException("No max latency set");
+        }
+        int min = 0;
+        if (minLatency != null) {
+            min = minLatency;
+        }
+        return random.nextInt(maxLatency - min) + min;
     }
 }

--- a/src/main/java/io/omnition/loadgenerator/util/TraceGenerator.java
+++ b/src/main/java/io/omnition/loadgenerator/util/TraceGenerator.java
@@ -95,7 +95,7 @@ public class TraceGenerator {
         } else {
             // no error, make downstream calls
             route.downstreamCalls.forEach((s, r) -> {
-                long childStartTimeMicros = startTimeMicros + TimeUnit.MILLISECONDS.toMicros(random.nextInt(route.maxLatencyMillis));
+                long childStartTimeMicros = startTimeMicros + TimeUnit.MILLISECONDS.toMicros(routeTags.randomLatency());
                 ServiceTier childSvc = this.topology.getServiceTier(s);
                 Span childSpan = createSpanForServiceRouteCall(routeTags, childSvc, r, childStartTimeMicros);
                 Reference ref = new Reference(RefType.CHILD_OF, span.id, childSpan.id);
@@ -110,7 +110,7 @@ public class TraceGenerator {
                 }
             });
         }
-        long ownDuration = TimeUnit.MILLISECONDS.toMicros((long)this.random.nextInt(route.maxLatencyMillis));
+        long ownDuration = TimeUnit.MILLISECONDS.toMicros(routeTags.randomLatency());
         span.endTimeMicros = maxEndTime.get() + ownDuration;
         trace.addSpan(span);
         return span;

--- a/topologies/100_000_spans_per_second.json
+++ b/topologies/100_000_spans_per_second.json
@@ -4,189 +4,170 @@
         {
           "serviceName" : "frontend",
           "instances" : [ "frontend-6b654dbf57-zq8dt", "frontend-d847fdcf5-j6s2f", "frontend-79d8c8d6c8-9sbff" ],
-          "tagSets": [{"tags" : { "version" : "v125", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v125", "region" : "us-east-1" }, "maxLatency": 200}],
           "routes" : [
             {
               "route" : "/product",
-              "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "recommendationservice" : "/GetRecommendations", "adservice" : "/AdRequest", "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" },
-              "maxLatencyMillis" : 200 
+              "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "recommendationservice" : "/GetRecommendations", "adservice" : "/AdRequest", "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" }
             },
             {
               "route" : "/alt_product_0",
-              "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "recommendationservice" : "/GetRecommendations", "adservice" : "/AdRequest", "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" },
-              "maxLatencyMillis" : 200 
+              "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "recommendationservice" : "/GetRecommendations", "adservice" : "/AdRequest", "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" }
             },
             {
               "route" : "/alt_product_1",
-              "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "recommendationservice" : "/GetRecommendations", "adservice" : "/AdRequest", "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" },
-              "maxLatencyMillis" : 200 
+              "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "recommendationservice" : "/GetRecommendations", "adservice" : "/AdRequest", "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" }
             },
             {
               "route" : "/alt_product_2",
-              "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "recommendationservice" : "/GetRecommendations", "adservice" : "/AdRequest", "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" },
-              "maxLatencyMillis" : 200 
+              "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "recommendationservice" : "/GetRecommendations", "adservice" : "/AdRequest", "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" }
             }
           ]
         },
         {
           "serviceName" : "productcatalogservice",
           "instances" : [ "productcatalogservice-6b654dbf57-zq8dt", "productcatalogservice-d847fdcf5-j6s2f" ],
-          "tagSets": [{"tags" : { "version" : "v52", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v52", "region" : "us-east-1" }, "maxLatency":  100}],
           "routes" : [
             {
               "route" : "/GetProducts",
-              "downstreamCalls" : { "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" },
-              "maxLatencyMillis" : 100 
+              "downstreamCalls" : { "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" }
             }
           ]
         },
         {
           "serviceName" : "recommendationservice",
           "instances" : [ "recommendationservice-6b654dbf57-zq8dt", "recommendationservice-d847fdcf5-j6s2f" ],
-          "tagSets": [{"tags" : { "version" : "v234", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v234", "region" : "us-east-1" }, "maxLatency": 100}],
           "routes" : [
             {
               "route" : "/GetRecommendations",
-              "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" },
-              "maxLatencyMillis" : 200 
+              "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4", "spanFiller5" : "/5", "spanFiller6" : "/6", "spanFiller7" : "/7", "spanFiller8" : "/8", "spanFiller9" : "/9" }
             }
           ]
         },
         {
           "serviceName" : "adservice",
           "instances" : [ "adservice-6b654dbf57-zq8dt", "adservice-d847fdcf5-j6s2f" ],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }, "maxLatency" : 500 }],
           "routes" : [
             {
               "route" : "/AdRequest",
-              "downstreamCalls" : { "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4" },
-              "maxLatencyMillis" : 500 
+              "downstreamCalls" : { "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4" }
             },
             {
               "route" : "/Ad",
-              "downstreamCalls" : { "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4" },
-              "maxLatencyMillis" : 500 
+              "downstreamCalls" : { "spanFiller0" : "/0", "spanFiller1" : "/1", "spanFiller2" : "/2", "spanFiller3" : "/3", "spanFiller4" : "/4" }
             }
           ]
         },
         {
           "serviceName" : "spanFiller0",
           "instances" : [ "spanfiller-6b654dbf57-00000" ],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }, "maxLatency":  1}],
           "routes" : [
             {
               "route" : "/0",
-              "downstreamCalls" : { },
-              "maxLatencyMillis" : 1 
+              "downstreamCalls" : { }
             }
           ]
         },
         {
           "serviceName" : "spanFiller1",
           "instances" : [ "spanfiller-6b654dbf57-00000" ],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }, "maxLatency":  1}],
           "routes" : [
             {
               "route" : "/1",
-              "downstreamCalls" : { },
-              "maxLatencyMillis" : 1 
+              "downstreamCalls" : { }
             }
           ]
         },
         {
           "serviceName" : "spanFiller2",
           "instances" : [ "spanfiller-6b654dbf57-00000" ],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }, "maxLatency":  1}],
           "routes" : [
             {
               "route" : "/2",
-              "downstreamCalls" : { },
-              "maxLatencyMillis" : 1 
+              "downstreamCalls" : { }
             }
           ]
         },
         {
           "serviceName" : "spanFiller3",
           "instances" : [ "spanfiller-6b654dbf57-00000" ],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }, "maxLatency":  1}],
           "routes" : [
             {
               "route" : "/3",
-              "downstreamCalls" : { },
-              "maxLatencyMillis" : 1 
+              "downstreamCalls" : { }
             }
           ]
         },
         {
           "serviceName" : "spanFiller4",
           "instances" : [ "spanfiller-6b654dbf57-00000" ],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }, "maxLatency":  1}],
           "routes" : [
             {
               "route" : "/4",
-              "downstreamCalls" : { },
-              "maxLatencyMillis" : 1
+              "downstreamCalls" : { }
             }
           ]
         },
         {
           "serviceName" : "spanFiller5",
           "instances" : [ "spanfiller-6b654dbf57-00000" ],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }, "maxLatency":  1}],
           "routes" : [
             {
               "route" : "/5",
-              "downstreamCalls" : { },
-              "maxLatencyMillis" : 1
+              "downstreamCalls" : { }
             }
           ]
         },
         {
           "serviceName" : "spanFiller6",
           "instances" : [ "spanfiller-6b654dbf57-00000" ],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }, "maxLatency":  1}],
           "routes" : [
             {
               "route" : "/6",
-              "downstreamCalls" : { },
-              "maxLatencyMillis" : 1
+              "downstreamCalls" : { }
             }
           ]
         },
         {
           "serviceName" : "spanFiller7",
           "instances" : [ "spanfiller-6b654dbf57-00000" ],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }, "maxLatency":  1}],
           "routes" : [
             {
               "route" : "/7",
-              "downstreamCalls" : { },
-              "maxLatencyMillis" : 1
+              "downstreamCalls" : { }
             }
           ]
         },
         {
           "serviceName" : "spanFiller8",
           "instances" : [ "spanfiller-6b654dbf57-00000" ],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }, "maxLatency":  1}],
           "routes" : [
             {
               "route" : "/8",
-              "downstreamCalls" : { },
-              "maxLatencyMillis" : 1
+              "downstreamCalls" : { }
             }
           ]
         },
         {
           "serviceName" : "spanFiller9",
           "instances" : [ "spanfiller-6b654dbf57-00000" ],
-          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }}],
+          "tagSets": [{"tags" : { "version" : "v37", "region" : "us-east-1" }, "maxLatency":  1}],
           "routes" : [
             {
               "route" : "/9",
-              "downstreamCalls" : { },
-              "maxLatencyMillis" : 1
+              "downstreamCalls" : { }
             }
           ]
         }

--- a/topologies/service_tags.json
+++ b/topologies/service_tags.json
@@ -5,19 +5,12 @@
         "serviceName" : "frontend",
         "instances" : [ "frontend-6b654dbf57-zq8dt", "frontend-d847fdcf5-j6s2f", "frontend-79d8c8d6c8-9sbff" ],
         "tagSets" : [
-          { "weight": 1, "tags": { "version" : "v127", "region" : "us-east-1" }, "maxLatency": 100},
-          { "weight": 1, "tags": { "version" : "v125", "region" : "us-east-1" }, "maxLatency": 100},
-          { "weight": 2, "tags": { "version" : "v125", "region" : "us-west-1" }, "maxLatency": 100}
+          { "weight": 2, "tags": { "version" : "v127", "region" : "us-west-1" }, "maxLatency": 100}
         ],
         "routes" : [
           {
             "route" : "/product",
-            "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "recommendationservice" : "/GetRecommendations", "adservice" : "/AdRequest" },
-            "tagSets": [
-              { "weight": 1, "tags": { "starter" : "charmander"}, "tagGenerators":  [{"numTags":  50, "numVals":  3000, "valLength": 16}]},
-              { "weight": 1, "tags": { "starter" : "squirtle"}},
-              { "weight": 1, "tags": { "starter" : "bulbasaur"}}
-            ]
+            "downstreamCalls" : { "productcatalogservice" : "/GetProducts", "recommendationservice" : "/GetRecommendations", "adservice" : "/AdRequest" }
           },
           {
             "route" : "/cart",
@@ -43,41 +36,45 @@
       {
         "serviceName" : "productcatalogservice",
         "instances" : [ "productcatalogservice-6b654dbf57-zq8dt", "productcatalogservice-d847fdcf5-j6s2f" ],
-        "tagSets" : [{"tags": { "version" : "v52"}, "inherit":  ["region"]}],
+        "tagSets" : [
+          {"weight": 3, "tags": { "version" : "v52", "region" : "us-west-1" }},
+          {"weight": 2, "tags": { "version" : "v52", "region" : "us-east-1", "error" : true, "http.status_code":  503}},
+          {"weight": 1, "tags": { "version" : "v52", "region" : "us-east-1"}}
+        ],
         "routes" : [
           {
             "route" : "/GetProducts",
             "downstreamCalls" : { },
-            "tagSets": [
-              {"inherit": ["starter"], "maxLatency":  100}
-            ]
+            "tagSets": [{"maxLatency": 100}]
           },
           {
             "route" : "/SearchProducts",
             "downstreamCalls" : { },
-            "tagSets" : [
-              {"weight": 15, "tags": { "error" : true, "http.status_code":  503}, "maxLatency": 400},
-              {"weight": 85, "tags":  {}, "maxLatency": 400}
-            ]
+            "tagSets": [{"maxLatency": 400}]
           }
         ]
       },
       {
         "serviceName" : "recommendationservice",
         "instances" : [ "recommendationservice-6b654dbf57-zq8dt", "recommendationservice-d847fdcf5-j6s2f" ],
-        "tagSets" : [{"tags" : { "version" : "v234", "region" : "us-east-1" }}],
+        "tagSets" : [
+          {"weight": 4, "tags" : { "version" : "v234"}, "inherit": ["region"], "maxLatency":  200},
+          {"weight": 1, "tags" : { "version" : "v235", "region" : "us-east-1", "error" : true, "http.status_code":  503}, "maxLatency":  200}
+        ],
         "routes" : [
           {
             "route" : "/GetRecommendations",
-            "downstreamCalls" : { "productcatalogservice" : "/GetProducts" },
-            "tagSets" : [{"maxLatency": 200}]
+            "downstreamCalls" : { "productcatalogservice" : "/GetProducts" }
           }
         ]
       },
       {
         "serviceName" : "cartservice",
         "instances" : [ "cartservice-6b654dbf57-zq8dt", "cartservice-d847fdcf5-j6s2f" ],
-        "tagSets": [{"tags" : { "version" : "v5", "region" : "us-east-1" }}],
+        "tagSets": [
+          {"tags" : { "version" : "v5", "region" : "us-east-1", "minLatency": 1000, "maxLatency":  5000}},
+          {"tags" : { "version" : "v5", "region" : "us-west-1", "maxLatency": 200}}
+        ],
         "routes" : [
           {
             "route" : "/GetCart",
@@ -89,15 +86,11 @@
       {
         "serviceName" : "checkoutservice",
         "instances" : [ "checkoutservice-6b654dbf57-zq8dt", "checkoutservice-d847fdcf5-j6s2f" ],
-        "tagSets": [{"maxLatency": 500, "tags" : { "version" : "v37", "region" : "us-east-1" }}],
+        "tagSets": [{"maxLatency": 500, "tags" : { "version" : "v37", "region" : "us-west-1" }}],
         "routes" : [
           {
             "route" : "/PlaceOrder",
-            "downstreamCalls" : { "paymentservice" : "/CreditCardInfo", "shippingservice" : "/Address", "currencyservice" : "/GetConversion", "cartservice" : "/GetCart", "emailservice" : "/SendOrderConfirmation" },
-            "tagSets" : [
-              {"weight": 25, "tags": { "error" : true, "http.status_code":  503}},
-              {"weight": 85, "tags":  {}}
-            ]
+            "downstreamCalls" : { "paymentservice" : "/CreditCardInfo", "shippingservice" : "/Address", "currencyservice" : "/GetConversion", "cartservice" : "/GetCart", "emailservice" : "/SendOrderConfirmation" }
           }
         ]
       },


### PR DESCRIPTION
Adds a new topology for the service tags demo, and additionally moves latency into TagSets, so that they can be specified along with tags. 