### PR TITLE
Replace mkdir with mkdir -p

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:8-jre-alpine
 
 # Define working directory.
-RUN mkdir /opt /opt/omnition /opt/omnition/topologies
+RUN mkdir -p /opt/omnition/topologies
 COPY target/SyntheticLoadGenerator-1.0-SNAPSHOT-jar-with-dependencies.jar /opt/omnition/synthetic-load-generator.jar
 COPY topologies/* /opt/omnition/topologies/
 COPY start.sh /opt/omnition/


### PR DESCRIPTION
Sometime docker build fails because some directories already exist.
making directories with the -p option should fix this.

Issue:

Testing Done: