### PR TITLE
Copy topologies directory structure instead of flat list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM openjdk:8-jre-alpine
 # Define working directory.
 RUN mkdir -p /opt/omnition/topologies
 COPY target/SyntheticLoadGenerator-1.0-SNAPSHOT-jar-with-dependencies.jar /opt/omnition/synthetic-load-generator.jar
-COPY topologies/* /opt/omnition/topologies/
+COPY topologies/. /opt/omnition/topologies/
 COPY start.sh /opt/omnition/
 RUN chmod +x /opt/omnition/start.sh
 WORKDIR /opt/omnition/


### PR DESCRIPTION
Docker has some very weird behavior on copying files with the COPY
command in which COPY dir/* /tmp/ will not copy the directory structure
but instead a flat list of all the files under that dir...

for a good time see https://github.com/moby/moby/issues/15858

Testing Done: locally