### PR TITLE
Add summarized logging and log verbosity command line option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "name": "Debug",
+      "request": "launch",
+      "mainClass": "io.omnition.loadgenerator.App",
+      "projectName": "SyntheticLoadGenerator",
+      "args": ["--paramsFile", "./topologies/hipster-shop.json", "--jaegerCollectorUrl", "http://localhost:14268", "--logLevel", "1"]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "package",
+      "type": "shell",
+      "command": "mvn package",
+      "group": "build",
+      "problemMatcher": []
+    },
+    {
+      "label": "verify",
+      "type": "shell",
+      "command": "mvn -B verify",
+      "group": "build"
+    },
+    {
+      "label": "test",
+      "type": "shell",
+      "command": "mvn -B test",
+      "group": "test"
+    }
+  ]
+}

--- a/src/main/java/io/omnition/loadgenerator/model/topology/ServiceTier.java
+++ b/src/main/java/io/omnition/loadgenerator/model/topology/ServiceTier.java
@@ -3,7 +3,6 @@ package io.omnition.loadgenerator.model.topology;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/io/omnition/loadgenerator/util/SummaryLogger.java
+++ b/src/main/java/io/omnition/loadgenerator/util/SummaryLogger.java
@@ -1,0 +1,56 @@
+package io.omnition.loadgenerator.util;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.log4j.Logger;
+
+/**
+ * SummaryLogger maintains global count of emitted traces and periodically
+ * outputs emitted counters and speed. Intended to be used as a single instance
+ * per app.
+ */
+public class SummaryLogger {
+    // How often to print summary log. 1 second.
+    private static final long SUM_LOG_PERIOD_NANOSEC = TimeUnit.NANOSECONDS.convert(1, TimeUnit.SECONDS);
+
+    // Last time summary log was printed, in monotinic nanoseconds
+    private long lastSumLogTimestampNano;
+
+    // Count of traces emited since summary log last printed
+    private long emitsSinceLastSumLog;
+    private long totalEmits;
+
+    private final Logger logger;
+
+    public SummaryLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * Count emitted traces and output summary if enough time elapsed since last
+     * output. This function is thread safe and can be called from multipler trace
+     * emitters concurrently.
+     */
+    public synchronized void logEmit(long emittedTraces) {
+        // Count emits
+        this.emitsSinceLastSumLog += emittedTraces;
+        this.totalEmits += emittedTraces;
+
+        // Check if it is time to output summary. Use nanoTime() as monotonic clock.
+        long curNanoTime = System.nanoTime();
+        long elapsedNano = curNanoTime - lastSumLogTimestampNano;
+        if (elapsedNano >= SummaryLogger.SUM_LOG_PERIOD_NANOSEC) {
+            // Calculate traces per second since last output
+            double elapsedSec = (double) elapsedNano / 1_000_000_000; // Using ugly division since TimeUnit
+                                                                      // does not support floating point operations.
+            double tracePerSecond = elapsedSec > 0 ? (double) emitsSinceLastSumLog / elapsedSec : 0;
+
+            logger.info(String.format("Emitted %d total, %d new traces, %.2f traces per second", totalEmits,
+                    emitsSinceLastSumLog, tracePerSecond));
+
+            // Reset counters to start measuring again
+            lastSumLogTimestampNano = curNanoTime;
+            emitsSinceLastSumLog = 0;
+        }
+    }
+}


### PR DESCRIPTION
synthetic-load-generator previously outputted one log line per emitted
trace which was too verbose for high generation speeds.

Made the following changes:

1. Added a command line flag to control verbosity of output. When
less verbose output is selected do not output logs per trace anymore.

2. Once per second output a summary of emitted traces. This output is
done in all verbosity levels.

Issue: A0-964

Testing Done: manual only, no automated tests for synthetic-load-generator