### PR TITLE
Add a sequence number to all generated spans

### DIFF
--- a/src/main/java/io/omnition/loadgenerator/util/ScheduledTraceGenerator.java
+++ b/src/main/java/io/omnition/loadgenerator/util/ScheduledTraceGenerator.java
@@ -52,7 +52,9 @@ public class ScheduledTraceGenerator {
     }
 
     public void shutdown() {
+        logger.info("Shutting down...");
         scheduler.shutdown();
+        this.summaryLogger.flush();
         try {
             if (!scheduler.awaitTermination(GRACEFUL_SHUTDOWN_TIME_SEC, TimeUnit.SECONDS)) {
                 logger.error("Executor did not terminate in the specified time.");

--- a/src/main/java/io/omnition/loadgenerator/util/TraceGenerator.java
+++ b/src/main/java/io/omnition/loadgenerator/util/TraceGenerator.java
@@ -26,6 +26,8 @@ public class TraceGenerator {
     private final Trace trace = new Trace();
     private Topology topology;
 
+    private static final AtomicLong sequenceNumber = new AtomicLong(1);
+
     public static Trace generate(Topology topology, String rootServiceName, String rootRouteName, long startTimeMicros) {
         TraceGenerator gen = new TraceGenerator(topology);
         ServiceTier rootService = gen.topology.getServiceTier(rootServiceName);
@@ -50,6 +52,7 @@ public class TraceGenerator {
         span.startTimeMicros = startTimeMicros;
         span.operationName = route.route;
         span.service = service;
+        span.tags.add(KeyValue.ofLongType("load_generator.seq_num", sequenceNumber.getAndIncrement()));
 
         // Setup base tags
         span.setHttpMethodTag("GET");


### PR DESCRIPTION
Every generated span now has an attribute "load_generator.seq_num" containing
an auto-incremented sequence number, starting from 1.

This is very useful for validating spans on the receiver side, it
allows to detect if any spans are missing or got duplicated.