### PR TITLE
Avoids failing on creating directory tree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:8-jre-alpine
 
 # Define working directory.
-RUN mkdir /opt /opt/omnition /opt/omnition/topologies
+RUN if [ ! -e "/opt/omnition/topologies" ]; then   mkdir -p "/opt/omnition/topologies"; fi;
 COPY target/SyntheticLoadGenerator-1.0-SNAPSHOT-jar-with-dependencies.jar /opt/omnition/synthetic-load-generator.jar
 COPY topologies/* /opt/omnition/topologies/
 COPY start.sh /opt/omnition/


### PR DESCRIPTION
Issue #35 fix

Avoids failing on creating directories tree by validating if the folders already exists before creating.