### PR TITLE
Prevent mkdir err

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:8-jre-alpine
 
 # Define working directory.
-RUN mkdir /opt /opt/omnition /opt/omnition/topologies
+RUN mkdir -p /opt/omnition/topologies
 COPY target/SyntheticLoadGenerator-1.0-SNAPSHOT-jar-with-dependencies.jar /opt/omnition/synthetic-load-generator.jar
 COPY topologies/* /opt/omnition/topologies/
 COPY start.sh /opt/omnition/


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

I get the following error when running `make build` because I already had an `/opt` dir:
```
 => ERROR [2/7] RUN mkdir /opt /opt/omnition /opt/omnition/topologies                                                                                                                                              
```

This PR uses the `mkdir -p` flag that performs an idempotent `mkdir` operation.